### PR TITLE
v.1.1.7 - Fixes main and types location & releases `1.1.7`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,16 @@
 {
   "name": "@lucasg04/jasmine-axe",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "license": "MIT",
   "scripts": {
     "build": "tsc",
+    "build:prod": "tsc -p tsconfig.prod.json",
     "test": "npm run build && jasmine",
     "clean": "rm -rf dist",
-    "release": "npm run clean && npm run build && npm publish"
+    "release": "npm run clean && npm run build:prod && npm publish"
   },
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
   "dependencies": {
     "axe-core": "^4.10.2"
   },

--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "outDir": "./dist/src",
+    },
+    "include": ["src/**/*"]
+  }


### PR DESCRIPTION
This pull request includes updates to the build and release process for the `@lucasg04/jasmine-axe` package, as well as changes to the output directory configuration. The most important changes are summarized below:

### Build and Release Process Improvements:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R13): Added a new script `build:prod` for production builds and updated the `release` script to use this new production build script.

### Configuration Updates:
* [`tsconfig.prod.json`](diffhunk://#diff-06e365ef3b4aed8cfd86bfa9f3af5567698f63a5ee88a9ea6ac555308e1ad402R1-R7): Introduced a new TypeScript configuration file for production builds, specifying the output directory as `./dist/src`.

### Other Changes:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R13): Updated the `main` and `types` fields to point to `dist/src` instead of `dist`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R13): Bumped the package version from `1.1.6` to `1.1.7`.