### PR TITLE
Fixes GitHub Actions workflow for testing and publishing

### DIFF
--- a/.github/workflows/npm-test-and-release.yml
+++ b/.github/workflows/npm-test-and-release.yml
@@ -9,7 +9,7 @@ on:
       - master
 
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
 
     steps:
@@ -28,10 +28,10 @@ jobs:
       - name: Run tests
         run: npm test
 
-  release:
+  publish:
     runs-on: ubuntu-latest
-    needs: build
-    if: github.ref == 'refs/heads/main'
+    needs: test
+    if: github.ref == 'refs/heads/master'
 
     steps:
       - name: Remove previous build


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow configuration to rename jobs and update dependencies between them.

Changes in the GitHub Actions workflow:

* [`.github/workflows/npm-test-and-release.yml`](diffhunk://#diff-40b37a549a71298b6f1b5da73d24c43b2b870c7d6a7a4e6e3657e21cb0759c25L12-R12): Renamed the `build` job to `test` and updated its dependencies accordingly.
* [`.github/workflows/npm-test-and-release.yml`](diffhunk://#diff-40b37a549a71298b6f1b5da73d24c43b2b870c7d6a7a4e6e3657e21cb0759c25L31-R34): Renamed the `release` job to `publish` and updated its dependencies to depend on the `test` job instead of the `build` job.